### PR TITLE
Avoid temporary allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triseratops"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Jan Holthuis <jan.holthuis@ruhr-uni-bochum.de>"]
 description = "The robust, in-depth Serato Parser & Serializer."
 readme = "README.md"

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,22 +49,20 @@ pub enum Error {
     IOError(#[from] std::io::Error),
 }
 
-fn convert_err(
-    item: &(&[u8], nom::error::VerboseErrorKind),
-) -> (Vec<u8>, nom::error::VerboseErrorKind) {
+fn map_err(item: (&[u8], nom::error::VerboseErrorKind)) -> (Vec<u8>, nom::error::VerboseErrorKind) {
     let (data, kind) = item;
-    (data.to_vec(), kind.to_owned())
+    (data.to_vec(), kind)
 }
 
 impl From<nom::Err<nom::error::VerboseError<&[u8]>>> for Error {
     fn from(e: nom::Err<nom::error::VerboseError<&[u8]>>) -> Self {
         match e {
             nom::Err::Error(err) => {
-                let errors = err.errors.iter().map(convert_err).collect();
+                let errors = err.errors.into_iter().map(map_err).collect();
                 Error::VerboseParseError { errors }
             }
             nom::Err::Failure(err) => {
-                let errors = err.errors.iter().map(convert_err).collect();
+                let errors = err.errors.into_iter().map(map_err).collect();
                 Error::VerboseParseError { errors }
             }
             nom::Err::Incomplete(_needed) => Error::ParseError,

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,7 +51,7 @@ pub enum Error {
 
 fn map_err(item: (&[u8], nom::error::VerboseErrorKind)) -> (Vec<u8>, nom::error::VerboseErrorKind) {
     let (data, kind) = item;
-    (data.to_vec(), kind)
+    (data.to_owned(), kind)
 }
 
 impl From<nom::Err<nom::error::VerboseError<&[u8]>>> for Error {

--- a/src/library/database.rs
+++ b/src/library/database.rs
@@ -109,7 +109,7 @@ fn take_u16_bytes(input: &[u8]) -> Res<&[u8], Vec<u16>> {
 
 fn parse_u16_text(input: &[u8]) -> Res<&[u8], String> {
     let (input, bytes) = nom::combinator::all_consuming(take_u16_bytes)(input)?;
-    let text = std::char::decode_utf16(bytes.iter().cloned())
+    let text = std::char::decode_utf16(bytes.into_iter())
         .map(|r| r.unwrap_or(std::char::REPLACEMENT_CHARACTER))
         .collect::<String>();
     Ok((input, text))
@@ -140,7 +140,7 @@ fn parse_field<'a, 'b>(input: &'a [u8], name: &'b [u8], field_type: u8) -> Res<&
                 //b"wlb" => ???
                 //b"wll" => ???
                 _ => Field::UnknownBoolean {
-                    name: name.to_vec(),
+                    name: name.to_owned(),
                     value,
                 },
             };
@@ -150,7 +150,7 @@ fn parse_field<'a, 'b>(input: &'a [u8], name: &'b [u8], field_type: u8) -> Res<&
             let (input, value) =
                 nom::combinator::all_consuming(nom::number::complete::be_u16)(input)?;
             let field = Field::UnknownU16Field {
-                name: name.to_vec(),
+                name: name.to_owned(),
                 value,
             };
             //b"bav" => ???
@@ -167,7 +167,7 @@ fn parse_field<'a, 'b>(input: &'a [u8], name: &'b [u8], field_type: u8) -> Res<&
                 //b"tkn" => ???
                 //b"dsc" => ???
                 _ => Field::UnknownU32Field {
-                    name: name.to_vec(),
+                    name: name.to_owned(),
                     value,
                 },
             };
@@ -180,7 +180,7 @@ fn parse_field<'a, 'b>(input: &'a [u8], name: &'b [u8], field_type: u8) -> Res<&
                 b"fil" => Field::FilePath(path),
                 b"trk" => Field::TrackPath(path),
                 _ => Field::UnknownPathField {
-                    name: name.to_vec(),
+                    name: name.to_owned(),
                     path,
                 },
             };
@@ -210,7 +210,7 @@ fn parse_field<'a, 'b>(input: &'a [u8], name: &'b [u8], field_type: u8) -> Res<&
                 b"vcw" => Field::ColumnWidth(text),
                 b"vrsn" => Field::Version(text),
                 _ => Field::UnknownTextField {
-                    name: name.to_vec(),
+                    name: name.to_owned(),
                     text,
                 },
             };
@@ -223,7 +223,7 @@ fn parse_field<'a, 'b>(input: &'a [u8], name: &'b [u8], field_type: u8) -> Res<&
                 b"trk" => Field::Track(fields),
                 b"vct" => Field::ColumnTitle(fields),
                 _ => Field::UnknownContainerField {
-                    name: name.to_vec(),
+                    name: name.to_owned(),
                     fields,
                 },
             };
@@ -232,14 +232,14 @@ fn parse_field<'a, 'b>(input: &'a [u8], name: &'b [u8], field_type: u8) -> Res<&
         FIELD_CONTAINER_R => {
             let (input, fields) = nom::combinator::all_consuming(take_fields)(input)?;
             let field = Field::UnknownContainerRField {
-                name: name.to_vec(),
+                name: name.to_owned(),
                 fields,
             };
             Ok((input, field))
         }
         _ => {
-            let name = name.to_vec();
-            let content = input.to_vec();
+            let name = name.to_owned();
+            let content = input.to_owned();
             Ok((
                 b"",
                 Field::Unknown {

--- a/src/tag/analysis.rs
+++ b/src/tag/analysis.rs
@@ -37,7 +37,7 @@ impl Tag for Analysis {
         Ok(analysis)
     }
 
-    fn write(&self, writer: impl io::Write) -> Result<usize, Error> {
+    fn write(&self, writer: &mut impl io::Write) -> Result<usize, Error> {
         write_analysis(writer, self)
     }
 }
@@ -59,7 +59,7 @@ impl ogg::OggTag for Analysis {
         Ok(analysis)
     }
 
-    fn write_ogg(&self, writer: impl io::Write) -> Result<usize, Error> {
+    fn write_ogg(&self, writer: &mut impl io::Write) -> Result<usize, Error> {
         write_analysis_ogg(writer, self)
     }
 }
@@ -110,12 +110,15 @@ pub fn parse_analysis_ogg(input: &[u8]) -> Result<Analysis, Error> {
 }
 
 /// Serialize [`Analysis` struct](Analysis) to bytes.
-pub fn write_analysis(writer: impl io::Write, analysis: &Analysis) -> Result<usize, Error> {
-    write_version(writer, &analysis.version)
+pub fn write_analysis(writer: &mut impl io::Write, analysis: &Analysis) -> Result<usize, Error> {
+    write_version(writer, analysis.version)
 }
 
 /// Serialize [`Analysis` struct](Analysis) to bytes ([Ogg](super::format::ogg) version).
-pub fn write_analysis_ogg(mut writer: impl io::Write, analysis: &Analysis) -> Result<usize, Error> {
+pub fn write_analysis_ogg(
+    writer: &mut impl io::Write,
+    analysis: &Analysis,
+) -> Result<usize, Error> {
     Ok(writer.write(&[
         analysis.version.major + 0x30,
         b'.',

--- a/src/tag/autotags.rs
+++ b/src/tag/autotags.rs
@@ -47,7 +47,7 @@ impl Tag for Autotags {
         Ok(autotags)
     }
 
-    fn write(&self, writer: impl io::Write) -> Result<usize, Error> {
+    fn write(&self, writer: &mut impl io::Write) -> Result<usize, Error> {
         write_autotags(writer, self)
     }
 }
@@ -100,7 +100,7 @@ fn take_autotags(input: &[u8]) -> Res<&[u8], Autotags> {
 }
 
 pub fn write_double_str(
-    mut writer: impl io::Write,
+    writer: &mut impl io::Write,
     number: f64,
     width: usize,
 ) -> Result<usize, Error> {
@@ -108,10 +108,10 @@ pub fn write_double_str(
     Ok(writer.write(number_str.as_bytes())?)
 }
 
-pub fn write_autotags(mut writer: impl io::Write, autotags: &Autotags) -> Result<usize, Error> {
-    let mut bytes_written = write_version(&mut writer, &autotags.version)?;
-    bytes_written += write_double_str(&mut writer, autotags.bpm, 2)?;
-    bytes_written += write_double_str(&mut writer, autotags.auto_gain, 3)?;
-    bytes_written += write_double_str(&mut writer, autotags.gain_db, 3)?;
+pub fn write_autotags(writer: &mut impl io::Write, autotags: &Autotags) -> Result<usize, Error> {
+    let mut bytes_written = write_version(writer, autotags.version)?;
+    bytes_written += write_double_str(writer, autotags.bpm, 2)?;
+    bytes_written += write_double_str(writer, autotags.auto_gain, 3)?;
+    bytes_written += write_double_str(writer, autotags.gain_db, 3)?;
     Ok(bytes_written)
 }

--- a/src/tag/beatgrid.rs
+++ b/src/tag/beatgrid.rs
@@ -67,7 +67,7 @@ impl Tag for Beatgrid {
         Ok(autotags)
     }
 
-    fn write(&self, writer: impl io::Write) -> Result<usize, Error> {
+    fn write(&self, writer: &mut impl io::Write) -> Result<usize, Error> {
         write_beatgrid(writer, self)
     }
 }
@@ -142,7 +142,7 @@ fn take_beatgrid(input: &[u8]) -> Res<&[u8], Beatgrid> {
 }
 
 pub fn write_non_terminal_marker(
-    mut writer: impl io::Write,
+    writer: &mut impl io::Write,
     marker: &NonTerminalMarker,
 ) -> Result<usize, Error> {
     let mut bytes_written = writer.write(&marker.position.to_be_bytes())?;
@@ -151,7 +151,7 @@ pub fn write_non_terminal_marker(
 }
 
 pub fn write_terminal_marker(
-    mut writer: impl io::Write,
+    writer: &mut impl io::Write,
     marker: &TerminalMarker,
 ) -> Result<usize, Error> {
     let mut bytes_written = writer.write(&marker.position.to_be_bytes())?;
@@ -159,14 +159,14 @@ pub fn write_terminal_marker(
     Ok(bytes_written)
 }
 
-pub fn write_beatgrid(mut writer: impl io::Write, beatgrid: &Beatgrid) -> Result<usize, Error> {
-    let mut bytes_written = write_version(&mut writer, &beatgrid.version)?;
+pub fn write_beatgrid(writer: &mut impl io::Write, beatgrid: &Beatgrid) -> Result<usize, Error> {
+    let mut bytes_written = write_version(writer, beatgrid.version)?;
     let num_markers = beatgrid.non_terminal_markers.len() as u32 + 1;
     bytes_written += writer.write(&num_markers.to_be_bytes())?;
     for marker in &beatgrid.non_terminal_markers {
-        bytes_written += write_non_terminal_marker(&mut writer, marker)?;
+        bytes_written += write_non_terminal_marker(writer, marker)?;
     }
-    bytes_written += write_terminal_marker(&mut writer, &beatgrid.terminal_marker)?;
+    bytes_written += write_terminal_marker(writer, &beatgrid.terminal_marker)?;
     bytes_written += writer.write(&[beatgrid.footer])?;
     Ok(bytes_written)
 }

--- a/src/tag/container.rs
+++ b/src/tag/container.rs
@@ -65,7 +65,7 @@ impl TagContainer {
     /// Write the [`Serato Autotags`](Autotags) tag.
     pub fn write_autotags(
         &self,
-        writer: impl io::Write,
+        writer: &mut impl io::Write,
         tag_format: TagFormat,
     ) -> Result<usize, Error> {
         let tag = match &self.autotags {
@@ -100,7 +100,7 @@ impl TagContainer {
     /// Write the [`Serato BeatGrid`](Beatgrid) tag.
     pub fn write_beatgrid(
         &self,
-        writer: impl io::Write,
+        writer: &mut impl io::Write,
         tag_format: TagFormat,
     ) -> Result<usize, Error> {
         let tag = match &self.beatgrid {
@@ -132,7 +132,7 @@ impl TagContainer {
     /// Write the [`Serato Markers_`](Markers) tag.
     pub fn write_markers(
         &self,
-        writer: impl io::Write,
+        writer: &mut impl io::Write,
         tag_format: TagFormat,
     ) -> Result<usize, Error> {
         let tag = match &self.markers {
@@ -168,7 +168,7 @@ impl TagContainer {
     /// Write the [`Serato Markers2`](Markers2) tag.
     pub fn write_markers2(
         &self,
-        writer: impl io::Write,
+        writer: &mut impl io::Write,
         tag_format: TagFormat,
     ) -> Result<usize, Error> {
         let tag = match &self.markers2 {
@@ -203,7 +203,7 @@ impl TagContainer {
     /// Write the [`Serato Overview`](Overview) tag.
     pub fn write_overview(
         &self,
-        writer: impl io::Write,
+        writer: &mut impl io::Write,
         tag_format: TagFormat,
     ) -> Result<usize, Error> {
         let tag = match &self.overview {
@@ -282,7 +282,7 @@ impl TagContainer {
                         continue;
                     }
                     markers::MarkerType::Cue => {
-                        if marker.start_position_millis == None {
+                        if marker.start_position == None {
                             // This shouldn't be possible if the `Serato Markers_` data is valid.
                             // Ideally, this should be checked during the parsing state.
                             // FIXME: Throw error here?
@@ -290,7 +290,7 @@ impl TagContainer {
                             continue;
                         }
 
-                        let position_millis = marker.start_position_millis.unwrap();
+                        let position = marker.start_position.unwrap();
 
                         // If the cue is set in both `Serato Markers2` and `Serato Markers_`, use
                         // the version from `Serato Markers_`, but keep the label from `Serato
@@ -305,7 +305,7 @@ impl TagContainer {
                             index,
                             generic::Cue {
                                 index,
-                                position_millis,
+                                position,
                                 color: marker.color,
                                 label,
                             },
@@ -345,15 +345,15 @@ impl TagContainer {
                     continue;
                 }
 
-                if marker.start_position_millis == None || marker.end_position_millis == None {
+                if marker.start_position == None || marker.end_position == None {
                     // This may happen even for valid data, because unset loops lack the start/end
                     // position.
                     map.remove(&index);
                     continue;
                 }
 
-                let start_position_millis = marker.start_position_millis.unwrap();
-                let end_position_millis = marker.end_position_millis.unwrap();
+                let start_position = marker.start_position.unwrap();
+                let end_position = marker.end_position.unwrap();
 
                 // If the loop is set in both `Serato Markers2` and `Serato Markers_`, use
                 // the version from `Serato Markers_`, but keep the label from `Serato
@@ -368,8 +368,8 @@ impl TagContainer {
                     index,
                     generic::Loop {
                         index,
-                        start_position_millis,
-                        end_position_millis,
+                        start_position,
+                        end_position,
                         color: marker.color,
                         label,
                         is_locked: marker.is_locked,

--- a/src/tag/container.rs
+++ b/src/tag/container.rs
@@ -267,7 +267,7 @@ impl TagContainer {
         // First, insert all cue from the `Serato Markers2` tag into the map.
         if let Some(m) = &self.markers2 {
             for cue in m.cues() {
-                map.insert(cue.index, cue);
+                map.insert(cue.index, cue.to_owned());
             }
         }
 
@@ -317,7 +317,7 @@ impl TagContainer {
         }
 
         // Return the sorted list of cues.
-        map.values().cloned().collect()
+        map.into_values().collect()
     }
 
     /// Returns loops from the [`Serato Markers_`](Markers) and [`Serato Markers2`](Markers2) tags.
@@ -331,7 +331,7 @@ impl TagContainer {
         // First, insert all cue from the `Serato Markers2` tag into the map.
         if let Some(m) = &self.markers2 {
             for saved_loop in m.loops() {
-                map.insert(saved_loop.index, saved_loop);
+                map.insert(saved_loop.index, saved_loop.to_owned());
             }
         }
 
@@ -379,46 +379,31 @@ impl TagContainer {
         }
 
         // Return the sorted list of cues.
-        map.values().cloned().collect()
+        map.into_values().collect()
     }
 
     /// Returns [flips](https://serato.com/dj/pro/expansions/flip) from the [`Serato Markers2`](Markers2) tag.
-    pub fn flips(&self) -> Vec<generic::Flip> {
-        if let Some(m) = &self.markers2 {
-            return m.flips();
-        }
-
-        vec![]
+    pub fn flips(&self) -> Option<impl Iterator<Item = &generic::Flip>> {
+        self.markers2.as_ref().map(Markers2::flips)
     }
 
     /// Returns the track color from the [`Serato Markers_`](Markers) and [`Serato
     /// Markers2`](Markers2) tags.
     ///
-    /// This retrieves the `Serato Markers2` track color first, then overwrites the value with the
-    /// one from `Serato Markers_`. This is what Serato does too (i.e. if `Serato Markers_` and
-    /// `Serato Markers2` contradict each other, Serato will use the value from `Serato
-    /// Markers_`).
+    /// If present the color in `Serato Markers_` takes precedence over that in
+    /// `Serato Markers2`. This is what Serato does too, i.e. if `Serato Markers_`
+    /// and `Serato Markers2` contradict each other, Serato will use the value
+    /// from `Serato Markers_`.
     pub fn track_color(&self) -> Option<Color> {
-        let mut track_color = None;
-
-        if let Some(m) = &self.markers2 {
-            track_color = m.track_color();
-        }
-
-        if let Some(m) = &self.markers {
-            track_color = Some(m.track_color());
-        }
-
-        track_color
+        self.markers
+            .as_ref()
+            .map(Markers::track_color)
+            .or_else(|| self.markers2.as_ref().and_then(Markers2::track_color))
     }
 
     /// Returns the waveform overview data color from the [`Serato Overview`](Overview) tag.
-    pub fn overview(&self) -> Option<&Vec<Vec<u8>>> {
-        if let Some(tag) = &self.overview {
-            return Some(&tag.data);
-        }
-
-        None
+    pub fn overview_data(&self) -> Option<&[Vec<u8>]> {
+        self.overview.as_ref().map(|overview| &overview.data[..])
     }
 }
 

--- a/src/tag/format/enveloped.rs
+++ b/src/tag/format/enveloped.rs
@@ -15,7 +15,7 @@ pub trait EnvelopedTag: Tag {
         Self::parse(&content)
     }
 
-    fn write_enveloped(&self, writer: impl io::Write) -> Result<usize, Error> {
+    fn write_enveloped(&self, writer: &mut impl io::Write) -> Result<usize, Error> {
         let mut buffer = Cursor::new(vec![]);
         self.write(&mut buffer)?;
         let plain_data = &buffer.get_ref()[..];
@@ -55,7 +55,7 @@ pub fn base64_decode(input: &[u8]) -> Result<Vec<u8>, Error> {
     }
 }
 
-pub fn base64_encode(mut writer: impl io::Write, input: &[u8]) -> Result<usize, Error> {
+pub fn base64_encode(writer: &mut impl io::Write, input: &[u8]) -> Result<usize, Error> {
     let mut bytes_written = 0;
     let chunks = input.chunks(54);
     let last_chunk_index = chunks.len() - 1;
@@ -93,7 +93,7 @@ pub fn envelope_decode_with_name(input: &[u8], expected_name: &str) -> Result<Ve
 }
 
 pub fn envelope_encode_with_name(
-    writer: impl io::Write,
+    writer: &mut impl io::Write,
     input: &[u8],
     name: &str,
 ) -> Result<usize, Error> {

--- a/src/tag/format/enveloped.rs
+++ b/src/tag/format/enveloped.rs
@@ -23,10 +23,10 @@ pub trait EnvelopedTag: Tag {
     }
 }
 
-pub fn parse_envelope(input: &[u8]) -> Result<(String, Vec<u8>), Error> {
+pub fn parse_envelope(input: &[u8]) -> Result<(&str, &[u8]), Error> {
     let (input, _) = nom::bytes::complete::tag(b"application/octet-stream\x00\x00")(input)?;
     let (input, name) = take_utf8(input)?;
-    Ok((name, input.to_vec()))
+    Ok((name, input))
 }
 
 pub fn is_base64(byte: u8) -> bool {
@@ -78,7 +78,7 @@ pub fn base64_encode(mut writer: impl io::Write, input: &[u8]) -> Result<usize, 
 
 pub fn envelope_decode(input: &[u8]) -> Result<(String, Vec<u8>), Error> {
     let data = base64_decode(input)?;
-    parse_envelope(data.as_slice())
+    parse_envelope(&data).map(|(s, b)| (s.to_owned(), b.to_owned()))
 }
 
 pub fn envelope_decode_with_name(input: &[u8], expected_name: &str) -> Result<Vec<u8>, Error> {

--- a/src/tag/format/flac.rs
+++ b/src/tag/format/flac.rs
@@ -14,7 +14,7 @@ pub trait FLACTag: EnvelopedTag {
         Self::parse_enveloped(input)
     }
 
-    fn write_flac(&self, writer: impl io::Write) -> Result<usize, Error> {
+    fn write_flac(&self, writer: &mut impl io::Write) -> Result<usize, Error> {
         self.write_enveloped(writer)
     }
 }

--- a/src/tag/format/id3.rs
+++ b/src/tag/format/id3.rs
@@ -12,7 +12,7 @@ pub trait ID3Tag: Tag {
         Self::parse(input)
     }
 
-    fn write_id3(&self, writer: impl io::Write) -> Result<usize, Error> {
+    fn write_id3(&self, writer: &mut impl io::Write) -> Result<usize, Error> {
         self.write(writer)
     }
 }

--- a/src/tag/format/mod.rs
+++ b/src/tag/format/mod.rs
@@ -12,5 +12,5 @@ use std::io;
 pub trait Tag: Sized {
     const NAME: &'static str;
     fn parse(input: &[u8]) -> Result<Self, Error>;
-    fn write(&self, writer: impl io::Write) -> Result<usize, Error>;
+    fn write(&self, writer: &mut impl io::Write) -> Result<usize, Error>;
 }

--- a/src/tag/format/mp4.rs
+++ b/src/tag/format/mp4.rs
@@ -18,7 +18,7 @@ pub trait MP4Tag: EnvelopedTag {
         Self::parse_enveloped(input)
     }
 
-    fn write_mp4(&self, writer: impl io::Write) -> Result<usize, Error> {
+    fn write_mp4(&self, writer: &mut impl io::Write) -> Result<usize, Error> {
         self.write_enveloped(writer)
     }
 }

--- a/src/tag/format/ogg.rs
+++ b/src/tag/format/ogg.rs
@@ -9,5 +9,5 @@ pub trait OggTag: Tag {
     const OGG_COMMENT: &'static str;
 
     fn parse_ogg(input: &[u8]) -> Result<Self, Error>;
-    fn write_ogg(&self, writer: impl io::Write) -> Result<usize, Error>;
+    fn write_ogg(&self, writer: &mut impl io::Write) -> Result<usize, Error>;
 }

--- a/src/tag/generic.rs
+++ b/src/tag/generic.rs
@@ -2,17 +2,25 @@
 use super::color::Color;
 
 /// Represents 2-Byte version value.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Version {
     pub major: u8,
     pub minor: u8,
+}
+
+/// Time-based position
+///
+/// Measured in milliseconds from the beginning of the track.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Position {
+    pub millis: u32,
 }
 
 /// A [cue point](https://support.serato.com/hc/en-us/articles/360000067696-Cue-Points).
 #[derive(Debug, Clone)]
 pub struct Cue {
     pub index: u8,
-    pub position_millis: u32,
+    pub position: Position,
     pub color: Color,
     pub label: String,
 }
@@ -21,8 +29,8 @@ pub struct Cue {
 #[derive(Debug, Clone)]
 pub struct Loop {
     pub index: u8,
-    pub start_position_millis: u32,
-    pub end_position_millis: u32,
+    pub start_position: Position,
+    pub end_position: Position,
     pub color: Color,
     pub is_locked: bool,
     pub label: String,

--- a/src/tag/markers.rs
+++ b/src/tag/markers.rs
@@ -10,7 +10,7 @@ use super::generic::{Position, Version};
 use super::serato32;
 use super::util::{take_color, take_version, write_color, write_version};
 use crate::error::Error;
-use crate::util::Res;
+use crate::util::{Res, NULL};
 use nom::error::ParseError;
 use std::io;
 use std::io::Cursor;
@@ -374,7 +374,7 @@ fn take_markers_mp4(input: &[u8]) -> Res<&[u8], Markers> {
 fn write_position(writer: &mut impl io::Write, position: Option<Position>) -> Result<usize, Error> {
     match position {
         Some(Position { millis }) => {
-            let mut bytes_written = writer.write(b"\x00")?;
+            let mut bytes_written = writer.write(NULL)?;
             bytes_written += serato32::write_u32(writer, millis)?;
             Ok(bytes_written)
         }
@@ -468,7 +468,7 @@ pub fn write_markers_mp4(writer: &mut impl io::Write, markers: &Markers) -> Resu
     for marker in &markers.entries {
         bytes_written += write_marker_mp4(writer, marker)?;
     }
-    bytes_written += writer.write(b"\x00")?;
+    bytes_written += writer.write(NULL)?;
     bytes_written += write_color(writer, markers.track_color)?;
     Ok(bytes_written)
 }

--- a/src/tag/markers.rs
+++ b/src/tag/markers.rs
@@ -126,7 +126,7 @@ impl mp4::MP4Tag for Markers {
             super::format::enveloped::take_base64_with_newline,
         )(input)?;
         let content = super::format::enveloped::envelope_decode_with_name(encoded, Self::NAME)?;
-        let (_, markers) = nom::combinator::all_consuming(take_markers_mp4)(content.as_slice())?;
+        let (_, markers) = nom::combinator::all_consuming(take_markers_mp4)(&content)?;
         Ok(markers)
     }
 

--- a/src/tag/overview.rs
+++ b/src/tag/overview.rs
@@ -58,7 +58,7 @@ impl mp4::MP4Tag for Overview {
 /// Returns a 16-byte vector of data parsed from the input slice.
 fn take_chunk(input: &[u8]) -> Res<&[u8], Vec<u8>> {
     let (input, chunkdata) = nom::bytes::complete::take(16usize)(input)?;
-    Ok((input, chunkdata.to_vec()))
+    Ok((input, chunkdata.to_owned()))
 }
 
 #[test]
@@ -70,11 +70,10 @@ fn test_take_chunk() {
         ]),
         Ok((
             &[0x10u8][..],
-            [
+            vec![
                 0x00u8, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
                 0x0d, 0x0e, 0x0f
             ]
-            .to_vec()
         ))
     );
     assert!(take_chunk(&[0xAB, 0x01]).is_err());

--- a/src/tag/overview.rs
+++ b/src/tag/overview.rs
@@ -41,7 +41,7 @@ impl Tag for Overview {
         Ok(overview)
     }
 
-    fn write(&self, writer: impl io::Write) -> Result<usize, Error> {
+    fn write(&self, writer: &mut impl io::Write) -> Result<usize, Error> {
         write_overview(writer, self)
     }
 }
@@ -93,15 +93,15 @@ fn take_overview(input: &[u8]) -> Res<&[u8], Overview> {
     Ok((input, overview))
 }
 
-fn write_chunk(mut writer: impl io::Write, chunk: &[u8]) -> Result<usize, Error> {
+fn write_chunk(writer: &mut impl io::Write, chunk: &[u8]) -> Result<usize, Error> {
     // TODO: Handle chunks with invalid size
     Ok(writer.write(chunk)?)
 }
 
-pub fn write_overview(mut writer: impl io::Write, overview: &Overview) -> Result<usize, Error> {
-    let mut bytes_written = write_version(&mut writer, &overview.version)?;
+pub fn write_overview(writer: &mut impl io::Write, overview: &Overview) -> Result<usize, Error> {
+    let mut bytes_written = write_version(writer, overview.version)?;
     for chunk in &overview.data {
-        bytes_written += write_chunk(&mut writer, chunk.as_slice())?;
+        bytes_written += write_chunk(writer, chunk.as_slice())?;
     }
     Ok(bytes_written)
 }

--- a/src/tag/relvolad.rs
+++ b/src/tag/relvolad.rs
@@ -40,7 +40,7 @@ impl Tag for RelVolAd {
         Ok(overview)
     }
 
-    fn write(&self, writer: impl io::Write) -> Result<usize, Error> {
+    fn write(&self, writer: &mut impl io::Write) -> Result<usize, Error> {
         write_relvolad(writer, self)
     }
 }
@@ -62,8 +62,8 @@ fn take_relvolad(input: &[u8]) -> Res<&[u8], RelVolAd> {
     Ok((input, relvolad))
 }
 
-fn write_relvolad(mut writer: impl io::Write, relvolad: &RelVolAd) -> Result<usize, Error> {
-    let mut bytes_written = write_version(&mut writer, &relvolad.version)?;
+fn write_relvolad(writer: &mut impl io::Write, relvolad: &RelVolAd) -> Result<usize, Error> {
+    let mut bytes_written = write_version(writer, relvolad.version)?;
     bytes_written += writer.write(relvolad.data.as_slice())?;
     Ok(bytes_written)
 }

--- a/src/tag/relvolad.rs
+++ b/src/tag/relvolad.rs
@@ -56,7 +56,7 @@ impl mp4::MP4Tag for RelVolAd {
 fn take_relvolad(input: &[u8]) -> Res<&[u8], RelVolAd> {
     let (input, version) = take_version(input)?;
     let (input, data) = nom::combinator::rest(input)?;
-    let data = data.to_vec();
+    let data = data.to_owned();
 
     let relvolad = RelVolAd { version, data };
     Ok((input, relvolad))

--- a/src/tag/serato32.rs
+++ b/src/tag/serato32.rs
@@ -94,7 +94,7 @@ pub fn take(input: &[u8]) -> Res<&[u8], (u8, u8, u8)> {
     Ok((input, value))
 }
 
-pub fn write(mut writer: impl io::Write, data: (u8, u8, u8)) -> Result<usize, Error> {
+pub fn write(writer: &mut impl io::Write, data: (u8, u8, u8)) -> Result<usize, Error> {
     let (in1, in2, in3) = data;
     let (byte1, byte2, byte3, byte4) = encode(in1, in2, in3);
     Ok(writer.write(&[byte1, byte2, byte3, byte4])?)
@@ -119,7 +119,7 @@ pub fn take_color(input: &[u8]) -> Res<&[u8], Color> {
     Ok((input, color))
 }
 
-pub fn write_color(writer: impl io::Write, color: &Color) -> Result<usize, Error> {
+pub fn write_color(writer: &mut impl io::Write, color: Color) -> Result<usize, Error> {
     write(writer, (color.red, color.green, color.blue))
 }
 
@@ -143,7 +143,7 @@ pub fn take_u32(input: &[u8]) -> Res<&[u8], u32> {
     Ok((input, value))
 }
 
-pub fn write_u32(writer: impl io::Write, value: u32) -> Result<usize, Error> {
+pub fn write_u32(writer: &mut impl io::Write, value: u32) -> Result<usize, Error> {
     let byte1 = ((value >> 16) & 0xFF) as u8;
     let byte2 = ((value >> 8) & 0xFF) as u8;
     let byte3 = (value & 0xFF) as u8;

--- a/src/tag/util.rs
+++ b/src/tag/util.rs
@@ -44,8 +44,9 @@ fn test_take_color() {
     assert!(take_color(&[0xAB, 0xCD]).is_err());
 }
 
-pub fn write_color(mut writer: impl io::Write, color: &Color) -> Result<usize, Error> {
-    Ok(writer.write(&[color.red, color.green, color.blue])?)
+pub fn write_color(writer: &mut impl io::Write, color: Color) -> Result<usize, Error> {
+    let Color { blue, green, red } = color;
+    Ok(writer.write(&[red, green, blue])?)
 }
 
 /// Returns a `Version` struct parsed from the first 2 input bytes.
@@ -73,6 +74,7 @@ fn test_take_version() {
     assert!(take_version(&[0x0A]).is_err());
 }
 
-pub fn write_version(mut writer: impl io::Write, version: &Version) -> Result<usize, Error> {
-    Ok(writer.write(&[version.major, version.minor])?)
+pub fn write_version(writer: &mut impl io::Write, version: Version) -> Result<usize, Error> {
+    let Version { major, minor } = version;
+    Ok(writer.write(&[major, minor])?)
 }

--- a/src/tag/vidassoc.rs
+++ b/src/tag/vidassoc.rs
@@ -42,7 +42,7 @@ impl Tag for VidAssoc {
         Ok(vidassoc)
     }
 
-    fn write(&self, writer: impl io::Write) -> Result<usize, Error> {
+    fn write(&self, writer: &mut impl io::Write) -> Result<usize, Error> {
         write_vidassoc(writer, self)
     }
 }
@@ -64,8 +64,8 @@ fn take_vidassoc(input: &[u8]) -> Res<&[u8], VidAssoc> {
     Ok((input, vidassoc))
 }
 
-fn write_vidassoc(mut writer: impl io::Write, vidassoc: &VidAssoc) -> Result<usize, Error> {
-    let mut bytes_written = write_version(&mut writer, &vidassoc.version)?;
+fn write_vidassoc(writer: &mut impl io::Write, vidassoc: &VidAssoc) -> Result<usize, Error> {
+    let mut bytes_written = write_version(writer, vidassoc.version)?;
     bytes_written += writer.write(vidassoc.data.as_slice())?;
     Ok(bytes_written)
 }

--- a/src/tag/vidassoc.rs
+++ b/src/tag/vidassoc.rs
@@ -58,7 +58,7 @@ impl mp4::MP4Tag for VidAssoc {
 fn take_vidassoc(input: &[u8]) -> Res<&[u8], VidAssoc> {
     let (input, version) = take_version(input)?;
     let (input, data) = nom::combinator::rest(input)?;
-    let data = data.to_vec();
+    let data = data.to_owned();
 
     let vidassoc = VidAssoc { version, data };
     Ok((input, vidassoc))

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,23 +25,18 @@ fn test_take_until_nullbyte() {
     assert!(take_until_nullbyte(&[0xAB, 0xCD]).is_err());
 }
 
-pub fn parse_utf8(input: &[u8]) -> Res<&[u8], String> {
-    let res = std::str::from_utf8(input);
-    match res {
-        Ok(s) => Ok((b"", s.to_owned())),
-        Err(_) => Err(nom::Err::Incomplete(nom::Needed::Unknown)),
-    }
+pub fn parse_utf8(input: &[u8]) -> Res<&[u8], &str> {
+    std::str::from_utf8(input)
+        .map(|s| (&b""[..], s))
+        .map_err(|_| nom::Err::Incomplete(nom::Needed::Unknown))
 }
 
 #[test]
 fn test_parse_utf8() {
-    assert_eq!(
-        parse_utf8(&[0x41, 0x42]),
-        Ok((&b""[..], String::from("AB")))
-    );
+    assert_eq!(parse_utf8(&[0x41, 0x42]), Ok((&b""[..], "AB")));
 }
 
-pub fn take_utf8(input: &[u8]) -> Res<&[u8], String> {
+pub fn take_utf8(input: &[u8]) -> Res<&[u8], &str> {
     let (input, data) = take_until_nullbyte(input)?;
     let (_, value) = parse_utf8(data)?;
     let (input, _) = nom::bytes::complete::take(1usize)(input)?;
@@ -50,8 +45,5 @@ pub fn take_utf8(input: &[u8]) -> Res<&[u8], String> {
 
 #[test]
 fn test_take_utf8() {
-    assert_eq!(
-        take_utf8(&[0x41, 0x42, 0x00]),
-        Ok((&b""[..], String::from("AB")))
-    );
+    assert_eq!(take_utf8(&[0x41, 0x42, 0x00]), Ok((&b""[..], "AB")));
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ use nom::bytes::complete::take_until;
 
 pub type Res<T, U> = nom::IResult<T, U, nom::error::VerboseError<T>>;
 
-const NULL: &[u8] = &[0x00];
+pub(crate) const NULL: &[u8] = &[0x00];
 
 /// Returns the input slice until the first occurrence of a null byte.
 pub fn take_until_nullbyte(input: &[u8]) -> Res<&[u8], &[u8]> {


### PR DESCRIPTION
...and many refactorings for type-safe (newtype + destructuring) and more idiomatic Rust code.

Decoupling the file path from the track avoids to store redundant data that is no needed.